### PR TITLE
fixing installer part script config/dovecot/config.source

### DIFF
--- a/config/dovecot/config.source
+++ b/config/dovecot/config.source
@@ -141,7 +141,7 @@ service dict {
   }
 }"
   echo $dovecotmaster > /etc/dovecot/conf.d/10-master.conf
-  echo "protocols = imap" > /etc/dovecot/conf.d/00-pop3-disable.conf
+  echo "protocols = imap lmtp" > /etc/dovecot/conf.d/00-pop3-disable.conf
   service dovecot restart
   service postfix restart
   echo -e "\n\nYour mail server should be accessible now.\n\n"


### PR DESCRIPTION
fixing installer parscript config/dovecot/config.source 

  has affect to: /etc/dovecot/conf.d/00-pop3-disable.conf
  protocols = imap
  changed to
 protocols = imap lmtp 